### PR TITLE
Fix 1300 lineage resolution

### DIFF
--- a/datacube/index/eo3.py
+++ b/datacube/index/eo3.py
@@ -10,6 +10,7 @@
 from affine import Affine
 from functools import reduce
 from typing import Dict, Any, Iterable, Optional, Tuple
+from uuid import UUID
 
 from datacube.utils.geometry import (
     SomeCRS,
@@ -228,11 +229,11 @@ def prep_eo3(doc: Dict[str, Any],
         if isinstance(uuids, dict) or isinstance(uuids[0], dict):
             raise ValueError("Embedded lineage not supported for eo3 metadata types")
         if len(uuids) == 1:
-            return {name: {'id': uuids[0]}}
+            return {name: {'id': str(uuids[0])}}
 
         out = {}
         for idx, uuid in enumerate(uuids, start=1):
-            out[name+str(idx)] = {'id': uuid}
+            out[name+str(idx)] = {'id': str(uuid)}
         return out
 
     sources = {}

--- a/datacube/index/eo3.py
+++ b/datacube/index/eo3.py
@@ -228,11 +228,11 @@ def prep_eo3(doc: Dict[str, Any],
         if isinstance(uuids, dict) or isinstance(uuids[0], dict):
             raise ValueError("Embedded lineage not supported for eo3 metadata types")
         if len(uuids) == 1:
-            return {name: {'id': uuids[0]}}
+            return {name: {'id': str(uuids[0])}}
 
         out = {}
         for idx, uuid in enumerate(uuids, start=1):
-            out[name+str(idx)] = {'id': uuid}
+            out[name+str(idx)] = {'id': str(uuid)}
         return out
 
     sources = {}


### PR DESCRIPTION
### Reason for this pull request

Fix issue #1300 [Doc2Dataset fails if lineage sources are specified as UUIDs rather than strings](https://github.com/opendatacube/datacube-core/issues/1300#)

### Proposed changes

- In datacube/index/eo3.py, `prep_eo3()`, convert lineage dataset ids to strings
- In datacube/index/hl.py, `_resolve_ds()`, stringify dataset ids for lookups
